### PR TITLE
issue #20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 secrets
 src/plugins/ucdlib-intranet/assets/assets/js
 src/plugins/ucdlib-intranet/assets/assets/css
+package-lock.json

--- a/reports/old-intranet-links/old_links.js
+++ b/reports/old-intranet-links/old_links.js
@@ -1,0 +1,215 @@
+import path from 'path';
+import { JSDOM } from 'jsdom';
+import { Parser as Json2csvParser } from 'json2csv';
+import { writeFile } from 'fs/promises';
+
+/**
+ * @description Class to generate a report of old intranet links from WordPress pages and groups
+ * @class OldLinksReport
+ * @param {Array} bases - array of base URLs to check for old links
+ */
+export default class OldLinksReport {
+  constructor(bases, config, dirname) {
+    this.pages = [];
+    this.groups = [];
+    this.report = [];
+    this.csv = '';
+    this.bases = bases;
+    this.dirname = dirname;
+
+    // Basic Auth
+    const username = config.wpUser;
+    const password = config.wpPass;
+    this.auth = "Basic " + Buffer.from(`${username}:${password}`).toString("base64");
+    this.pages_endpoint = `${config.wpBase}/pages?context=edit&per_page=${config.wpPage}`;
+    this.groups_endpoint = `${config.wpBase}/ucdlib-group?context=edit&per_page=${config.wpPage}`;
+  }
+
+  /**
+   * @description generate the report
+  */
+  async generate() {
+    this.pages = await this.fetchLinks(this.pages_endpoint);
+    this.groups = await this.fetchLinks(this.groups_endpoint);
+    
+    for (const p of this.pages) {
+        console.log(`Processing page ID ${p.id} - ${p.slug}`);
+    }
+    for (const g of this.groups) {
+        console.log(`Processing group ID ${g.id} - ${g.slug}`);
+    }
+    this.processLinks();
+    this.saveReport();
+  }
+
+    /**
+     * @description flatten refs from extractedRefs
+     * @param {Array} extractedRefs
+     * @return {Array} flattened refs
+     */
+    flattenRefs(extractedRefs = []) {
+        return (extractedRefs || []).reduce((acc, item) => {
+            const { type, id, permalink, slug } = item;
+            for (const { linktype, url, text, alt } of (item.refs || [])) {
+                acc.push({ type, id, permalink, slug, linktype, url, text, alt });
+            }
+        return acc;
+        }, []);
+    }
+
+    /**
+     * @description extract refs info from html content
+     * @param {String} html WP_REST content
+     * @param {Object} instance page or group instance
+     * @returns {Object|Boolean} info object or false if no refs found
+     */
+    extractRefsInfo(html, instance={}) {
+        let info = {
+            type: instance.type || 'unknown',
+            id: instance.id || 0,
+            permalink: instance.link || '',
+            slug: instance.slug || '',
+        };
+        const refs = [];
+
+        const BASES = this.bases ;
+
+        const prefixes = BASES.map(s => s.toLowerCase());
+        const isFromBase = (u = '') =>
+            typeof u === 'string' &&
+            prefixes.some(p => u.toLowerCase().startsWith(p));
+                
+        const dom = new JSDOM(html || '');
+        const doc = dom.window.document;
+        
+        const aTags = Array.from(doc.links)
+            .filter(n => n.tagName === 'A')
+            .map(a => ({
+            href: a.getAttribute('href') || '',
+            text: (a.textContent || '').replace(/\s+/g, ' ').trim() // normalize whitespace
+            }))
+            .filter(({ href }) => isFromBase(href));
+    
+        const imgTags = Array.from(doc.images)
+            .map(img => ({
+            src: img.getAttribute('src') || '',
+            alt: img.getAttribute('alt') || ''
+            }))
+            .filter(({ src }) => isFromBase(src));
+        
+        if (aTags.length) {
+            refs.push(...aTags.map(({ href, text }) => ({
+            linktype: 'a',
+            url: href,
+            text
+            })));
+        }
+        if (imgTags.length) {
+            refs.push(...imgTags.map(({ src, alt }) => ({
+            linktype: 'img',
+            url: src,
+            alt
+            })));
+        }
+
+        return refs.length ? { ...info, refs } : false;
+    }
+    
+    /**
+     * @description convert old links report to CSV format
+     * @param {Object} old_links 
+     * @returns {String} CSV string
+     */
+    csvFormat(old_links){
+        const fields = ['type', 'id', 'permalink', 'slug', 'linktype', 'url', 'text', 'alt'];
+        const opts = { fields, quote: '"' };
+        try {
+            const parser = new Json2csvParser(opts);
+            const csv = parser.parse(old_links);
+            return csv;
+        } catch (err) {
+            console.error(err);
+            return '';
+        }
+    }
+
+    /**
+     * @description process links from pages and groups
+     */
+    async processLinks() {
+        const extractedRefs = [];
+
+        for (const p of this.pages ?? []) {
+            const html = p?.content?.rendered ?? p?.content?.raw ?? '';
+            const info = this.extractRefsInfo(html, p);
+            if (info) extractedRefs.push(info);
+        }
+
+        for (const g of this.groups ?? []) {
+            const html = g?.content?.rendered ?? g?.content?.raw ?? '';
+            const info = this.extractRefsInfo(html, g);
+            if (info) extractedRefs.push(info);
+        }
+
+        this.report = this.flattenRefs(extractedRefs);
+
+
+        console.log(`Found ${this.report.length} old intranet links in ${this.pages.length} pages and ${this.groups.length} groups.`);
+        this.csv = this.csvFormat(this.report);
+    }
+
+    /**
+     * @description save report to CSV file
+     * @returns {void}
+    */
+    saveReport() {
+        const OUTPUT_CSV = path.join(this.dirname, 'old_intranet_links_report.csv');
+        writeFile(OUTPUT_CSV, this.csv)
+        .then(() => {
+            console.log(`Report saved to ${OUTPUT_CSV}`);
+        })
+        .catch(err => {
+            console.error('Error saving report:', err);
+        });
+    }
+
+    /**
+     * @description fetch links from a given URL with Basic Auth
+     * @param {String} url 
+     * @returns 
+     */
+    async fetchLinks(url) {
+        const all = [];
+        let totalPages = 1;
+      
+        const headers = {
+          Accept: "application/json",
+          ...(this.auth ? { Authorization: this.auth } : {})
+        };
+      
+        const u = new URL(url);
+      
+        for (let page = 1; page <= totalPages; page++) {
+          u.searchParams.set("page", String(page));
+      
+          const res = await fetch(u.toString(), { headers });
+      
+          if (!res.ok) {
+            const body = await res.text().catch(() => "");
+            throw new Error(`Failed to fetch ${u}: ${res.status} ${res.statusText}\n${body}`);
+          }
+      
+          if (page === 1) {
+            totalPages = Number(res.headers.get("X-WP-TotalPages")) || 1;
+            console.log(`Fetching ${totalPages} pages from ${url}`);
+          }
+      
+          const data = await res.json();
+          if (Array.isArray(data)) all.push(...data);
+          else return data; // if not a collection endpoint, return as-is
+        }
+      
+        return all;
+      }
+      
+}

--- a/reports/old-intranet-links/reports-old-links.js
+++ b/reports/old-intranet-links/reports-old-links.js
@@ -1,0 +1,69 @@
+#! /usr/bin/env node
+
+import { Command } from 'commander';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { config } from 'dotenv';
+import OldLinksReport from './old_links.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+/**
+ * @description CLI to run OldLinksReport
+ * @module reports-old-links
+ * @example
+ *   $ reports old-links
+ *   $ reports old-links https://staff.library.ucdavis.edu http://staff.library.ucdavis.edu
+ *   $ reports old-links https://staff.library.ucdavis.edu http://staff.library.ucdavis.edu -e ./reports/old-intranet-links/.env -d ./reports
+ *   $ reports old-links -e ./reports/old-intranet-links/.env
+ *   $ reports old-links -e ./reports/old-intranet-links/.env -d ./reports
+ */
+
+const program = new Command();
+program
+  .name('old-links')
+  .description('Scan WordPress content for old links')
+  .argument('[bases...]', 'Base URLs to check (default: https://staff.library.ucdavis.edu and http://staff.library.ucdavis.edu)')
+  .option('-e, --env <path>', 'Path to .env file', path.join(__dirname, '.env'))
+  .option('-d, --destination <path>', 'Path to destination folder for reports', __dirname)
+  .action(async (bases, options) => {
+    if (!bases || bases.length === 0) {
+      bases = [
+        'https://staff.library.ucdavis.edu',
+        'http://staff.library.ucdavis.edu',
+      ];
+    }
+    let envPath = null;
+
+    let desinationPath = path.isAbsolute(options.destination)
+      ? options.destination
+      : path.resolve(process.cwd(), options.destination);
+
+    if (options.env) {
+      envPath = path.isAbsolute(options.env)
+      ? options.env
+      : path.resolve(process.cwd(), options.env);    
+    }
+
+    const out = envPath ? config({ path: envPath }): config();
+
+    if (out.error) {
+      console.error('.env credentials needed:', out.error);
+      process.exit(1);
+    }
+
+    console.log('Loaded .env from:', envPath);
+    console.log('Checking bases:', bases);
+
+    const baseConfig = {
+      wpBase: process.env.WP_API_BASE || "https://stage.staff.library.ucdavis.edu/wp-json/wp/v2",
+      wpUser: process.env.WP_API_USER || "USERNAME",
+      wpPass: process.env.WP_API_PASS || "PASSWORD",
+      wpPage: process.env.WP_API_PER_PAGE || 100,
+    }
+
+    await new OldLinksReport(bases, baseConfig, desinationPath).generate();
+  });
+
+program.parse(process.argv);

--- a/reports/package.json
+++ b/reports/package.json
@@ -1,0 +1,15 @@
+{  
+  "name": "reports-cli",
+  "version": "1.0.0",
+  "type": "module",
+  "bin": {
+    "reports": "./reports.js",
+    "reports-old-links": "./old-intranet-links/reports-old-links.js"
+  },
+  "dependencies": {
+    "commander": "^14.0.1",
+    "dotenv": "^17.2.2",
+    "jsdom": "^27.0.0",
+    "json2csv": "^6.0.0-alpha.2"
+  }
+}

--- a/reports/reports.js
+++ b/reports/reports.js
@@ -1,0 +1,13 @@
+#! /usr/bin/env node
+
+import { Command } from 'commander';
+
+const program = new Command();
+program
+  .name('reports')
+  .description('CLI tools for intranet reports')
+  .version('1.0.0');
+
+program.command('old-links', 'Scan WordPress content for old links');
+
+program.parse(process.argv);


### PR DESCRIPTION
For this I created a new reports folder for later use of documenting reports, only having one right now which is old_intranet_links.

I made it reusable and having cli functionality for if other reporting scripts are necessary, however this may be unnecessary and overly done.  This includes:

- The fetching feature for both ucdlib-groups and pages the give all of the data to parse through
- The looking for links in a tags and img tags
- Creating and recording a csv file for the results, which you can automatically goes to the directory where the file is located - and takes from a local env for the sensitive data (both can be changed but is made to run outside docker)
	
Some added features:
-  Added commander with the idea that more than one report script can be added to it
-  Let .env files and destination file be added in
-  Allowed for this to be used for other old links rather than have built in staff.library url
-  Added .env file usability for extra security instead of typing in to command line

Examples commands for CLI:

```
/**
 *   $ reports old-links
 *   $ reports old-links https://staff.library.ucdavis.edu http://staff.library.ucdavis.edu
 *   $ reports old-links https://staff.library.ucdavis.edu http://staff.library.ucdavis.edu -e ./reports/old-intranet-links/.env -d ./reports
 *   $ reports old-links -e ./reports/old-intranet-links/.env
 *   $ reports old-links -e ./reports/old-intranet-links/.env -d ./reports
*/

```